### PR TITLE
fix: bumping alpine version to resolve cves

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # This image is made to work with the related Helm chart. It lacks config files on purpose.
 
 # Build stage
-FROM alpine:3.17 as build
+FROM alpine:3.18 as build
 ARG REPO_TAG
 
 # Install build dependencies
@@ -42,7 +42,7 @@ RUN make
 RUN make install
 
 # Runtime stage
-FROM alpine:3.17
+FROM alpine:3.18
 
 # Install runtime dependencies
 RUN apk add -U --no-cache busybox udns libevent postgresql-client


### PR DESCRIPTION
This PR resolves the following CVEs:

- https://nvd.nist.gov/vuln/detail/CVE-2022-28391
- https://nvd.nist.gov/vuln/detail/CVE-2022-30065
- https://nvd.nist.gov/vuln/detail/CVE-2024-4741
- https://nvd.nist.gov/vuln/detail/CVE-2024-5535

Solves https://github.com/icoretech/helm/issues/8